### PR TITLE
Transform clases to non static

### DIFF
--- a/src/main/java/no/entur/grpc/interceptor/client/ValidationInterceptor.java
+++ b/src/main/java/no/entur/grpc/interceptor/client/ValidationInterceptor.java
@@ -40,7 +40,17 @@ import no.entur.protobuf.validation.ProtobufValidator;
  */
 public class ValidationInterceptor implements ClientInterceptor {
 
-	private ProtobufValidator validator = new ProtobufValidator();
+	private ProtobufValidator validator;
+
+
+	public ValidationInterceptor(ProtobufValidator validator) {
+		this.validator = validator;
+	}
+
+	public ValidationInterceptor() {
+		this(ProtobufValidator.globalValidator());
+	}
+
 
 	@Override
 	public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {

--- a/src/main/java/no/entur/grpc/interceptor/server/ValidationInterceptor.java
+++ b/src/main/java/no/entur/grpc/interceptor/server/ValidationInterceptor.java
@@ -43,7 +43,17 @@ public class ValidationInterceptor implements ServerInterceptor {
 
 	private final static Logger LOGGER = Logger.getLogger(ValidationInterceptor.class.getName());
 
-	private ProtobufValidator validator = new ProtobufValidator();
+	private ProtobufValidator validator;
+
+
+	public ValidationInterceptor(ProtobufValidator validator) {
+		this.validator = validator;
+	}
+
+	public ValidationInterceptor() {
+		this(ProtobufValidator.globalValidator());
+	}
+
 
 	@Override
 	public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(final ServerCall<ReqT, RespT> call, final Metadata headers,

--- a/src/main/java/no/entur/protobuf/validation/ProtobufValidator.java
+++ b/src/main/java/no/entur/protobuf/validation/ProtobufValidator.java
@@ -34,7 +34,7 @@ import com.google.protobuf.GeneratedMessageV3;
  */
 public class ProtobufValidator {
 
-	private static ProtobufValidator globalProtobufValidator = new ProtobufValidator(ValidatorRegistry.globalValidatorRegistry());
+	private static ProtobufValidator globalProtobufValidator = new ProtobufValidator();
 
 	private ValidatorRegistry validatorRegistry;
 
@@ -44,6 +44,13 @@ public class ProtobufValidator {
 	public ProtobufValidator(ValidatorRegistry validatorRegistry) {
 		this.validatorRegistry = validatorRegistry;
 	}
+
+    /**
+     * The default constructor which uses the global {@link ValidatorRegistry}.
+     */
+	public ProtobufValidator() {
+	    this(ValidatorRegistry.globalValidatorRegistry());
+    }
 
 	private void doValidate(GeneratedMessageV3 message, FieldDescriptor fieldDescriptor, Object fieldValue, DescriptorProtos.FieldOptions options)
 			throws IllegalArgumentException, MessageValidationException {
@@ -83,10 +90,16 @@ public class ProtobufValidator {
 		}
 	}
 
+    /**
+     * @return The globally shared {@link ProtobufValidator}.
+     */
 	public static ProtobufValidator globalValidator() {
 		return globalProtobufValidator;
 	}
 
+    /**
+     * @return A {@link ProtobufValidator} with a default {@link ValidatorRegistry}.
+     */
 	public static ProtobufValidator createDefaultValidator() {
 		return new ProtobufValidator(ValidatorRegistry.createDefaultRegistry());
 	}

--- a/src/main/java/no/entur/protobuf/validation/ValidatorRegistry.java
+++ b/src/main/java/no/entur/protobuf/validation/ValidatorRegistry.java
@@ -47,14 +47,25 @@ public class ValidatorRegistry {
 
 	private Map<Descriptors.FieldDescriptor, Validator> validatorMap;
 
+    /**
+     * Constructor which builds a {@link ValidatorRegistry} with predefined validators from the validatorMap.
+     */
 	public ValidatorRegistry(Map<Descriptors.FieldDescriptor, Validator> validatorMap) {
 		this.validatorMap = validatorMap;
 	}
 
+    /**
+     * The default constructor which builds a empty {@link ValidatorRegistry}.
+     */
 	public ValidatorRegistry() {
 		this(Maps.newConcurrentMap());
 	}
 
+    /**
+     * @param descriptor The descriptor for which the {@link Validator} should be removed.
+     * @return {@link Validator} The validator for a {@link com.google.protobuf.Descriptors.FieldDescriptor} or
+     *         null if none is registered.
+     */
 	public Validator getValidator(Descriptors.FieldDescriptor descriptor) {
 		return validatorMap.get(descriptor);
 	}
@@ -100,7 +111,9 @@ public class ValidatorRegistry {
 		}
 	}
 
-
+    /**
+     * @return The globally shared {@link ValidatorRegistry}.
+     */
 	public static ValidatorRegistry globalValidatorRegistry() {
 		return globalValidatorRegistry;
 	}

--- a/src/main/java/no/entur/protobuf/validation/ValidatorRegistry.java
+++ b/src/main/java/no/entur/protobuf/validation/ValidatorRegistry.java
@@ -42,21 +42,87 @@ import validation.Validation;
  * @author seime
  */
 public class ValidatorRegistry {
-	private static final Map<Descriptors.FieldDescriptor, Validator> REGISTRY = Maps.newHashMap();
 
-	static {
-		REGISTRY.put(Validation.max.getDescriptor(), new MaxValidator());
-		REGISTRY.put(Validation.min.getDescriptor(), new MinValidator());
-		REGISTRY.put(Validation.repeatMax.getDescriptor(), new RepeatMaxValidator());
-		REGISTRY.put(Validation.repeatMin.getDescriptor(), new RepeatMinValidator());
-		REGISTRY.put(Validation.future.getDescriptor(), new FutureValidator());
-		REGISTRY.put(Validation.past.getDescriptor(), new PastValidator());
-		REGISTRY.put(Validation.regex.getDescriptor(), new RegexValidator());
-		REGISTRY.put(Validation.required.getDescriptor(), new RequiredValidator());
-		REGISTRY.put(Validation.forbidden.getDescriptor(), new ForbiddenValidator());
+	private static ValidatorRegistry globalValidatorRegistry = createDefaultRegistry();
+
+	private Map<Descriptors.FieldDescriptor, Validator> validatorMap;
+
+	public ValidatorRegistry(Map<Descriptors.FieldDescriptor, Validator> validatorMap) {
+		this.validatorMap = validatorMap;
 	}
 
-	public static Validator getValidator(Descriptors.FieldDescriptor descriptor) {
-		return REGISTRY.get(descriptor);
+	public ValidatorRegistry() {
+		this(Maps.newConcurrentMap());
+	}
+
+	public Validator getValidator(Descriptors.FieldDescriptor descriptor) {
+		return validatorMap.get(descriptor);
+	}
+
+	/**
+	 * Adds a {@link Validator} for a {@link com.google.protobuf.Descriptors.FieldDescriptor}.
+	 * If there is already a {@link Validator} for a {@link com.google.protobuf.Descriptors.FieldDescriptor}
+	 * the previous {@link Validator} will be overridden.
+	 *
+	 * @param fieldDescriptor The {@link com.google.protobuf.Descriptors.FieldDescriptor} to add
+	 * @param validator The {@link Validator} to add in context with the fieldDescriptor
+	 */
+	public void addValidator(Descriptors.FieldDescriptor fieldDescriptor, Validator validator) {
+		validatorMap.put(fieldDescriptor, validator);
+	}
+
+	/**
+	 * Adds multiple {@link Validator}s in context to their {@link com.google.protobuf.Descriptors.FieldDescriptor}.
+	 * If there is already a {@link Validator} for a {@link com.google.protobuf.Descriptors.FieldDescriptor}
+	 * the previous {@link Validator} will be overridden.
+	 *
+	 * @param validators The {@link com.google.protobuf.Descriptors.FieldDescriptor} to add
+	 */
+	public void addValidators(Map<Descriptors.FieldDescriptor, Validator> validators) {
+		validatorMap.putAll(validators);
+	}
+
+	/**
+	 * @param fieldDescriptor The {@link com.google.protobuf.Descriptors.FieldDescriptor}
+	 *                        for which the {@link Validator} should be removed.
+	 */
+	public void removeValidator(Descriptors.FieldDescriptor fieldDescriptor) {
+		validatorMap.remove(fieldDescriptor);
+	}
+
+	/**
+	 * @param fieldDescriptors The {@link com.google.protobuf.Descriptors.FieldDescriptor}s
+	 *                        for which their {@link Validator}s should be removed.
+	 */
+	public void removeValidator(Iterable<Descriptors.FieldDescriptor> fieldDescriptors) {
+		for (Descriptors.FieldDescriptor fieldDescriptor : fieldDescriptors) {
+			validatorMap.remove(fieldDescriptor);
+		}
+	}
+
+
+	public static ValidatorRegistry globalValidatorRegistry() {
+		return globalValidatorRegistry;
+	}
+
+	/**
+	 * @return A {@link ValidatorRegistry} with all built-in validators.
+	 */
+	public static ValidatorRegistry createDefaultRegistry() {
+
+		ValidatorRegistry validatorRegistry = new ValidatorRegistry();
+
+		Map<Descriptors.FieldDescriptor, Validator> validatorMap = validatorRegistry.validatorMap;
+		validatorMap.put(Validation.max.getDescriptor(), new MaxValidator());
+		validatorMap.put(Validation.min.getDescriptor(), new MinValidator());
+		validatorMap.put(Validation.repeatMax.getDescriptor(), new RepeatMaxValidator());
+		validatorMap.put(Validation.repeatMin.getDescriptor(), new RepeatMinValidator());
+		validatorMap.put(Validation.future.getDescriptor(), new FutureValidator());
+		validatorMap.put(Validation.past.getDescriptor(), new PastValidator());
+		validatorMap.put(Validation.regex.getDescriptor(), new RegexValidator());
+		validatorMap.put(Validation.required.getDescriptor(), new RequiredValidator());
+		validatorMap.put(Validation.forbidden.getDescriptor(), new ForbiddenValidator());
+
+		return validatorRegistry;
 	}
 }


### PR DESCRIPTION
This PR transforms all classes to be non static to be able to:
- have multiple instances of a ValidatorRegistry
- add own Validators
- create beans of these classes for dependency injection in for example spring boot
- specify which ProtobufValidator a ValidationInterceptor should use. This is especially useful with multiple grpc client stubs


There are still static methods to get for example the global validator registry or global protobuf validator. These are still automatically used when no parameters on instantiation of a ProtobufValidator or ValidationInterceptor are specified.
